### PR TITLE
First try at length field based coded

### DIFF
--- a/tokio-codec/src/length_field_based_codec.rs
+++ b/tokio-codec/src/length_field_based_codec.rs
@@ -1,0 +1,83 @@
+use std::{fmt, io, usize};
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+use crate::decoder::Decoder;
+use crate::encoder::Encoder;
+
+/// A simple `Codec` implementation that reads a byte
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+pub struct LengthFieldBasedCodec {
+    max_frame_length: usize
+}
+
+impl LengthFieldBasedCodec {
+    /// Creates a new `LengthFieldBasedCodec` for shipping around raw bytes.
+    pub fn new(max_frame_length: usize) -> LengthFieldBasedCodec {
+        LengthFieldBasedCodec {
+            max_frame_length
+        }
+    }
+}
+
+impl Decoder for LengthFieldBasedCodec {
+    type Item = BytesMut;
+    type Error = LengthFieldBasedCodecError;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<BytesMut>, LengthFieldBasedCodecError> {
+        if !buf.is_empty() {
+            let length = buf[0] as usize;
+            if length > self.max_frame_length {
+                Err(LengthFieldBasedCodecError::MaxFrameLengthExceeded)
+            } else {
+                let len = buf.len();
+                if len >= length {
+                    buf.advance(1);
+                    return Ok(Some(buf.split_to(length)));
+                } else {
+                    Ok(None)
+                }
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl Encoder for LengthFieldBasedCodec {
+    type Item = Bytes;
+    type Error = io::Error;
+
+    fn encode(&mut self, data: Bytes, buf: &mut BytesMut) -> Result<(), io::Error> {
+        buf.reserve(data.len());
+        buf.put(data);
+        Ok(())
+    }
+}
+
+
+/// An error occurred while encoding or decoding a frame.
+#[derive(Debug)]
+pub enum LengthFieldBasedCodecError {
+    /// The maximum frame length was exceeded.
+    MaxFrameLengthExceeded,
+    /// An IO error occured.
+    Io(io::Error),
+}
+
+impl fmt::Display for LengthFieldBasedCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LengthFieldBasedCodecError::MaxFrameLengthExceeded => write!(f, "max frame length exceeded"),
+            LengthFieldBasedCodecError::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl From<io::Error> for LengthFieldBasedCodecError {
+    fn from(e: io::Error) -> LengthFieldBasedCodecError {
+        LengthFieldBasedCodecError::Io(e)
+    }
+}
+
+impl std::error::Error for LengthFieldBasedCodecError {}

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -19,6 +19,7 @@
 mod macros;
 
 mod bytes_codec;
+mod length_field_based_codec;
 mod decoder;
 mod encoder;
 mod framed;
@@ -27,6 +28,7 @@ mod framed_write;
 mod lines_codec;
 
 pub use crate::bytes_codec::BytesCodec;
+pub use crate::length_field_based_codec::LengthFieldBasedCodec;
 pub use crate::decoder::Decoder;
 pub use crate::encoder::Encoder;
 pub use crate::framed::{Framed, FramedParts};


### PR DESCRIPTION
Add some tests (working) and some code (working)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

[Netty's LengthFieldBasedFrameDecoder](https://netty.io/4.0/api/io/netty/handler/codec/LengthFieldBasedFrameDecoder.html)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Quick and dirty implementation
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
